### PR TITLE
Fix HACS download

### DIFF
--- a/hacs.json
+++ b/hacs.json
@@ -3,4 +3,5 @@
   "hide_default_branch": true,
   "zip_release": true,
   "filename": "historical_stats.zip",
+  "content_in_root": true
 }


### PR DESCRIPTION
## Summary
- ensure zip-based releases extract correctly by marking content in root

## Testing
- `bash scripts/lint.sh`

------
https://chatgpt.com/codex/tasks/task_e_687f6dad94148328bcc3add03b85b591