### PR TITLE
Fix manifest JSON quoting

### DIFF
--- a/custom_components/historical_stats/manifest.json
+++ b/custom_components/historical_stats/manifest.json
@@ -8,7 +8,7 @@
   "documentation": "https://github.com/krissen/historical_stats",
   "issue_tracker": "https://github.com/krissen/historical_stats/issues",
   "requirements": [],
-  iot_class: "local_polling",
+  "iot_class": "local_polling",
   "version": "2025.6.10"
 }
 


### PR DESCRIPTION
## Summary
- quote the `iot_class` key in `manifest.json`

## Testing
- `bash scripts/lint.sh`

------
https://chatgpt.com/codex/tasks/task_e_687f780b661c83288920ca457dd2936d