### PR TITLE
Fix full history query

### DIFF
--- a/custom_components/historical_stats/sensor.py
+++ b/custom_components/historical_stats/sensor.py
@@ -44,7 +44,7 @@ class HistoricalStatsSensor(SensorEntity):
 
             try:
                 if unit == "all":
-                    start = None
+                    start = dt_util.utc_from_timestamp(0)
                     end = now
                 else:
                     delta = {


### PR DESCRIPTION
## Summary
- handle 'all history' queries correctly by passing Unix epoch as start time

## Testing
- `./scripts/lint.sh`

------
https://chatgpt.com/codex/tasks/task_e_687f7b8d55dc832894dc3e03cbb37608