### PR TITLE
Add edit option and timestamp attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,9 @@ For Home Assistant to recognize the new integration, restart the server.
 
 5. Save and finish.
 
-All statistics for the entity will be available as attributes on a new sensor entity, e.g.  
+All statistics for the entity will be available as attributes on a new sensor entity, e.g.
 `sensor.historical_statistics_sensor_outside_temperature`
+The attribute naming follows `<period>_<statistic>` where the period is `unit_value` like `days_7` or simply `full` for all history. Example: `days_7_min`.
 
 ---
 
@@ -69,7 +70,7 @@ All statistics for the entity will be available as attributes on a new sensor en
 - Period: Days ago
 - Value: 1
 
-2. The result appears as the attribute `value_at_1_days` on your sensor.
+2. The result appears as the attribute `days_1_value_at` on your sensor.
 
 ---
 

--- a/custom_components/historical_stats/translations/en.json
+++ b/custom_components/historical_stats/translations/en.json
@@ -1,48 +1,57 @@
 {
-  "config": {
-    "step": {
-      "user": {
-        "title": "Configure Historical statistics",
-        "description": "Select the source entity and update interval.",
-        "data": {
-          "entity_id": "Entity",
-          "update_interval": "Update interval (minutes)"
-        }
-      },
-      "add_point": {
-        "title": "Add measurement point",
-        "description": "{info}",
-        "data": {
-          "stat_types": "Statistics types",
-          "time_unit": "Time unit",
-          "time_value": "Time value",
-          "add_another": "Add another"
-        }
-      }
+    "config": {
+        "step": {
+            "user": {
+                "title": "Configure Historical statistics",
+                "description": "Select the source entity and update interval.",
+                "data": {
+                    "entity_id": "Entity",
+                    "update_interval": "Update interval (minutes)",
+                },
+            },
+            "add_point": {
+                "title": "Add measurement point",
+                "description": "{info}",
+                "data": {
+                    "stat_types": "Statistics types",
+                    "time_unit": "Time unit",
+                    "time_value": "Time value",
+                    "add_another": "Add another",
+                },
+            },
+        },
+        "error": {},
     },
-    "error": {}
-  },
-  "options": {
-    "step": {
-      "init": {
-        "title": "Configure measurement points",
-        "description": "{current_points}",
-        "data": {
-          "add_point": "Add point",
-          "remove_index": "Remove index",
-          "finish": "Finish"
+    "options": {
+        "step": {
+            "init": {
+                "title": "Configure measurement points",
+                "description": "{current_points}",
+                "data": {
+                    "add_point": "Add point",
+                    "remove_index": "Remove index",
+                    "edit_index": "Edit index",
+                    "finish": "Finish",
+                },
+            },
+            "add_point": {
+                "title": "Add measurement point",
+                "description": "Set the parameters for the measurement point.",
+                "data": {
+                    "stat_type": "Statistic type",
+                    "time_unit": "Time unit",
+                    "time_value": "Time value",
+                },
+            },
+            "edit_point": {
+                "title": "Edit measurement point",
+                "description": "Update the parameters for the measurement point.",
+                "data": {
+                    "stat_type": "Statistic type",
+                    "time_unit": "Time unit",
+                    "time_value": "Time value",
+                },
+            },
         }
-      },
-      "add_point": {
-        "title": "Add measurement point",
-        "description": "Set the parameters for the measurement point.",
-        "data": {
-          "stat_type": "Statistic type",
-          "time_unit": "Time unit",
-          "time_value": "Time value"
-        }
-      }
-    }
-  }
+    },
 }
-


### PR DESCRIPTION
## Summary
- allow editing measurement points in options flow
- rename attributes using `<period>_<statistic>` scheme
- expose timestamp attributes for `min`, `max` and `value_at` measurements
- update docs and translations

## Testing
- `ruff format custom_components/historical_stats/sensor.py`
- `ruff format custom_components/historical_stats/config_flow.py`
- `ruff format custom_components/historical_stats/translations/en.json`
- `ruff check . --fix`

------
https://chatgpt.com/codex/tasks/task_e_687f7ddbf7008328a930e497699b1211