### PR TITLE
Improve friendly names and options flow

### DIFF
--- a/custom_components/historical_stats/translations/en.json
+++ b/custom_components/historical_stats/translations/en.json
@@ -6,7 +6,8 @@
                 "description": "Select the source entity and update interval.",
                 "data": {
                     "entity_id": "Entity",
-                    "update_interval": "Update interval (minutes)"
+                    "update_interval": "Update interval (minutes)",
+                    "friendly_name": "Custom name"
                 }
             },
             "add_point": {
@@ -29,8 +30,8 @@
                 "description": "{current_points}",
                 "data": {
                     "add_point": "Add point",
-                    "remove_index": "Remove index",
-                    "edit_index": "Edit index",
+                    "remove_indices": "Remove points",
+                    "edit_index": "Edit point",
                     "finish": "Finish"
                 }
             },


### PR DESCRIPTION
## Summary
- default friendly name uses source entity friendly name
- allow custom friendly name via config
- improve options UI with multi-select and fix entry creation
- add `suggested_object_id` for stable entity ids

## Testing
- `scripts/lint.sh`

------
https://chatgpt.com/codex/tasks/task_e_687faf68327c83289418815df2eeb64d