### PR TITLE
Automate manifest version in release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,6 +15,10 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v3
 
+      - name: Set manifest version
+        run: |
+          python3 scripts/update_version.py "${{ github.ref_name }}"
+
       - name: Create zip
         run: |
           cd custom_components/historical_stats

--- a/custom_components/historical_stats/manifest.json
+++ b/custom_components/historical_stats/manifest.json
@@ -8,6 +8,7 @@
   "iot_class": "local_polling",
   "requirements": [],
   "issue_tracker": "https://github.com/krissen/historical_stats/issues",
-  "config_flow": true
+  "config_flow": true,
+  "version": "0.0.3-beta1"
 }
 

--- a/scripts/update_version.py
+++ b/scripts/update_version.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+"""Update manifest version for release packaging.
+
+This script sets the "version" key in the manifest to the
+value provided on the command line.
+"""
+
+import json
+import sys
+from pathlib import Path
+
+MANIFEST_PATH = (
+    Path(__file__).parent.parent
+    / "custom_components"
+    / "historical_stats"
+    / "manifest.json"
+)
+
+
+def main() -> None:
+    if len(sys.argv) != 2:
+        print("Usage: update_version.py <version>")
+        sys.exit(1)
+
+    version = sys.argv[1]
+
+    # Load manifest JSON
+    data = json.loads(MANIFEST_PATH.read_text())
+
+    # Update version key
+    data["version"] = version
+
+    # Write back with 2-space indentation
+    MANIFEST_PATH.write_text(json.dumps(data, indent=2) + "\n")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add version field to manifest
- script for updating manifest version
- use script in release workflow

## Testing
- `scripts/lint.sh`

------
https://chatgpt.com/codex/tasks/task_e_687fc83fae648328bf198ea9bc49fe40