### PR TITLE
Remove redundant timestamp attributes

### DIFF
--- a/custom_components/historical_stats/config_flow.py
+++ b/custom_components/historical_stats/config_flow.py
@@ -9,7 +9,7 @@ from homeassistant.helpers.selector import (
     TextSelector,
 )
 
-from .const import DOMAIN
+from .const import DOMAIN, ERROR_INVALID_COMBINATION
 
 # Available statistic types
 STAT_TYPES = [
@@ -98,9 +98,8 @@ class HistoricalStatsConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 any(t in selected_types for t in ["value_at", "total"])
                 and len(selected_types) > 1
             ):
-                errors["stat_types"] = (
-                    "Value at / Total cannot be combined with other types."
-                )
+                # Use translation key for error to support localization
+                errors["stat_types"] = ERROR_INVALID_COMBINATION
             else:
                 for stat_type in selected_types:
                     self.measure_points.append(

--- a/custom_components/historical_stats/const.py
+++ b/custom_components/historical_stats/const.py
@@ -4,3 +4,6 @@ PLATFORMS = ["sensor"]
 STATE_OK = "OK"
 STATE_NO_DATA = "NO_DATA"
 STATE_ERROR = "ERROR"
+
+# Translation keys
+ERROR_INVALID_COMBINATION = "invalid_combination"

--- a/custom_components/historical_stats/sensor.py
+++ b/custom_components/historical_stats/sensor.py
@@ -82,9 +82,6 @@ class HistoricalStatsSensor(SensorEntity):
                         if found:
                             attrs[label] = found.state
                             attrs[f"{label}_ts"] = found.last_changed.isoformat()
-                            attrs[f"{label}_ts_human"] = dt_util.as_local(
-                                found.last_changed
-                            ).strftime("%Y-%m-%d %H:%M:%S")
                         else:
                             attrs[label] = STATE_UNKNOWN
                         continue
@@ -108,16 +105,10 @@ class HistoricalStatsSensor(SensorEntity):
                     min_val, min_state = min(numeric_states, key=lambda x: x[0])
                     attrs[label] = min_val
                     attrs[f"{label}_ts"] = min_state.last_changed.isoformat()
-                    attrs[f"{label}_ts_human"] = dt_util.as_local(
-                        min_state.last_changed
-                    ).strftime("%Y-%m-%d %H:%M:%S")
                 elif stat_type == "max":
                     max_val, max_state = max(numeric_states, key=lambda x: x[0])
                     attrs[label] = max_val
                     attrs[f"{label}_ts"] = max_state.last_changed.isoformat()
-                    attrs[f"{label}_ts_human"] = dt_util.as_local(
-                        max_state.last_changed
-                    ).strftime("%Y-%m-%d %H:%M:%S")
                 elif stat_type == "mean":
                     attrs[label] = sum(values_only) / len(values_only)
                 elif stat_type == "total":

--- a/custom_components/historical_stats/translations/en.json
+++ b/custom_components/historical_stats/translations/en.json
@@ -21,7 +21,9 @@
                 }
             }
         },
-        "error": {}
+        "error": {
+            "invalid_combination": "Value at / Total cannot be combined with other types."
+        }
     },
     "options": {
         "step": {


### PR DESCRIPTION
## Summary
- drop `_ts_human` attributes from sensor
- show config flow error via translation key
- add missing translation string for the new error

## Testing
- `scripts/lint.sh`

------
https://chatgpt.com/codex/tasks/task_e_687fcc5d0ec883289efdcfc70c3c54fa