### PR TITLE
Fix full history retrieval

### DIFF
--- a/custom_components/historical_stats/sensor.py
+++ b/custom_components/historical_stats/sensor.py
@@ -171,14 +171,17 @@ class HistoricalStatsSensor(SensorEntity):
         """Return all recorded states in interval."""
         return (
             await self.hass.async_add_executor_job(
-                get_significant_states,
-                self.hass,
-                start,
-                end,
-                [self._entity_id],
-                None,
-                True,
-                False,
+                lambda: get_significant_states(
+                    self.hass,
+                    start,
+                    end,
+                    [self._entity_id],
+                    None,
+                    True,  # minimal_response
+                    False,  # no_attributes
+                    False,  # include all state changes
+                    True,  # include state at start time
+                )
             )
         )[self._entity_id]
 


### PR DESCRIPTION
## Summary
- retrieve start time state and all state changes in `_get_states_interval`

## Testing
- `bash scripts/lint.sh`

------
https://chatgpt.com/codex/tasks/task_e_6880a5fe23688328b3cef3b50f29eb56