### PR TITLE
Reload integration on options update

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,13 @@ For Home Assistant to recognize the new integration, restart the server.
 
 5. Save and finish.
 
+### Editing measurement points
+
+To modify the configuration later, open **Settings > Devices & Services**, locate
+your *Historical statistics* entry and choose **Configure**. You can then add,
+edit or remove points and press **Save changes**. The sensor will reload
+automatically with the new settings.
+
 All statistics for the entity will be available as attributes on a new sensor entity, e.g.
 `sensor.historical_statistics_sensor_outside_temperature`
 The attribute naming follows `<period>_<statistic>` where the period is `unit_value` like `days_7` or simply `full` for all history. Example: `days_7_min`.

--- a/custom_components/historical_stats/__init__.py
+++ b/custom_components/historical_stats/__init__.py
@@ -4,11 +4,17 @@ from .const import DOMAIN, PLATFORMS
 
 
 async def async_setup_entry(hass, entry):
-    """Set up the integration and forward to supported platforms."""
+    """Set up the integration and reload when options change."""
     hass.data.setdefault(DOMAIN, {})
     hass.data[DOMAIN][entry.entry_id] = entry.data
+    entry.async_on_unload(entry.add_update_listener(async_reload_entry))
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     return True
+
+
+async def async_reload_entry(hass, entry):
+    """Reload the config entry when its options are updated."""
+    await hass.config_entries.async_reload(entry.entry_id)
 
 
 async def async_unload_entry(hass, entry):

--- a/custom_components/historical_stats/translations/de.json
+++ b/custom_components/historical_stats/translations/de.json
@@ -31,7 +31,7 @@
           "add_point": "Messpunkt hinzufügen",
           "remove_indices": "Messpunkte entfernen",
           "edit_index": "Messpunkt bearbeiten",
-          "finish": "Fertig"
+          "finish": "Änderungen speichern"
         }
       },
       "add_point": {
@@ -67,7 +67,7 @@
     "days": "Vor Tagen",
     "weeks": "Vor Wochen",
     "months": "Vor Monaten",
-    "years": "Dieses Jahr",
-    "all": "Gesamte Historie"
+    "years": "Vor Jahren",
+    "all": "Seit jeher"
   }
 }

--- a/custom_components/historical_stats/translations/dk.json
+++ b/custom_components/historical_stats/translations/dk.json
@@ -31,7 +31,7 @@
           "add_point": "Tilføj målepunkt",
           "remove_indices": "Fjern målepunkter",
           "edit_index": "Redigér målepunkt",
-          "finish": "Afslut"
+          "finish": "Gem ændringer"
         }
       },
       "add_point": {
@@ -67,7 +67,7 @@
     "days": "Dage siden",
     "weeks": "Uger siden",
     "months": "Måneder siden",
-    "years": "Dette år",
-    "all": "Al historik"
+    "years": "For år siden",
+    "all": "Al tid"
   }
 }

--- a/custom_components/historical_stats/translations/en.json
+++ b/custom_components/historical_stats/translations/en.json
@@ -69,6 +69,6 @@
         "weeks": "Weeks ago",
         "months": "Months ago",
         "years": "Years ago",
-        "all": "Ever"
+        "all": "All time"
     }
 }

--- a/custom_components/historical_stats/translations/en.json
+++ b/custom_components/historical_stats/translations/en.json
@@ -68,7 +68,7 @@
         "days": "Days ago",
         "weeks": "Weeks ago",
         "months": "Months ago",
-        "years": "This year",
-        "all": "All history"
+        "years": "Years ago",
+        "all": "Ever"
     }
 }

--- a/custom_components/historical_stats/translations/en.json
+++ b/custom_components/historical_stats/translations/en.json
@@ -32,7 +32,7 @@
                     "add_point": "Add point",
                     "remove_indices": "Remove points",
                     "edit_index": "Edit point",
-                    "finish": "Finish"
+                    "finish": "Save changes"
                 }
             },
             "add_point": {

--- a/custom_components/historical_stats/translations/es.json
+++ b/custom_components/historical_stats/translations/es.json
@@ -31,7 +31,7 @@
           "add_point": "Agregar punto",
           "remove_indices": "Eliminar puntos",
           "edit_index": "Editar punto",
-          "finish": "Finalizar"
+          "finish": "Guardar cambios"
         }
       },
       "add_point": {
@@ -67,7 +67,7 @@
     "days": "Hace días",
     "weeks": "Hace semanas",
     "months": "Hace meses",
-    "years": "Este año",
-    "all": "Todo el historial"
+    "years": "Hace años",
+    "all": "Todo el tiempo"
   }
 }

--- a/custom_components/historical_stats/translations/fi.json
+++ b/custom_components/historical_stats/translations/fi.json
@@ -31,7 +31,7 @@
           "add_point": "Lisää piste",
           "remove_indices": "Poista pisteet",
           "edit_index": "Muokkaa pistettä",
-          "finish": "Valmis"
+          "finish": "Tallenna muutokset"
         }
       },
       "add_point": {
@@ -67,7 +67,7 @@
     "days": "Päivää sitten",
     "weeks": "Viikkoa sitten",
     "months": "Kuukautta sitten",
-    "years": "Tänä vuonna",
-    "all": "Koko historia"
+    "years": "Vuotta sitten",
+    "all": "Kaikki ajat"
   }
 }

--- a/custom_components/historical_stats/translations/no.json
+++ b/custom_components/historical_stats/translations/no.json
@@ -31,7 +31,7 @@
           "add_point": "Legg til punkt",
           "remove_indices": "Fjern punkter",
           "edit_index": "Rediger punkt",
-          "finish": "Fullfør"
+          "finish": "Lagre endringer"
         }
       },
       "add_point": {
@@ -67,7 +67,7 @@
     "days": "Dager siden",
     "weeks": "Uker siden",
     "months": "Måneder siden",
-    "years": "I år",
-    "all": "All historikk"
+    "years": "For år siden",
+    "all": "All tid"
   }
 }

--- a/custom_components/historical_stats/translations/sv.json
+++ b/custom_components/historical_stats/translations/sv.json
@@ -31,7 +31,7 @@
           "add_point": "Lägg till mätpunkt",
           "remove_indices": "Ta bort mätpunkter",
           "edit_index": "Redigera mätpunkt",
-          "finish": "Klar"
+          "finish": "Spara ändringar"
         }
       },
       "add_point": {
@@ -67,7 +67,7 @@
     "days": "Dagar sedan",
     "weeks": "Veckor sedan",
     "months": "Månader sedan",
-    "years": "I år",
-    "all": "All historik"
+    "years": "För år sedan",
+    "all": "Någonsin"
   }
 }


### PR DESCRIPTION
## Summary
- reload integration automatically when options are saved
- clarify the "Finish" option text
- document how to edit measurement points

## Testing
- `scripts/lint.sh`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880c0f89ab083288c1a2f812bcd865f