### PR TITLE
Add cumulative and custom range features

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Historical statistics
 
-A custom integration for [Home Assistant](https://www.home-assistant.io/) that exposes user-defined historical statistics for any entity with numerical stats. This component allows you to create virtual sensors that show min, max, mean, exact value at time, or total change over custom time periods.
+A custom integration for [Home Assistant](https://www.home-assistant.io/) that exposes user-defined historical statistics for any entity with numerical stats. This component allows you to create virtual sensors that show min, max, mean, exact value at time, total change, or sum over custom time periods.
 
 <img width="469" height="376" alt="Skärmavbild 2025-07-23 kl  12 32 31" src="https://github.com/user-attachments/assets/53c343c4-77f1-4cde-83ee-cc1431ea4f38" />
 
@@ -9,8 +9,9 @@ A custom integration for [Home Assistant](https://www.home-assistant.io/) that e
 ## Features
 
 - **Any source entity:** Works with any numeric sensor or entity with a numeric state.
-- **Configurable measurement points:** Define as many time-based statistics as you want, such as "max last 7 days", "mean last 30 days", "value 24 hours ago", or "total change this month".
-- **Multiple statistics per time window:** Easily select several statistics (min, max, mean) for a single period in one step.
+- **Configurable measurement points:** Define as many time-based statistics as you want, such as "max last 7 days", "mean last 30 days", "value 24 hours ago", "total change this month", or "sum last year".
+- **Custom time ranges:** Specify both the starting point and the ending point for each measurement.
+- **Multiple statistics per time window:** Easily select several statistics (min, max, mean, sum) for a single period in one step.
 - **All configuration via UI:** No YAML or manual editing needed; set up and edit everything through Home Assistant’s user interface.
 - **Entity attributes:** All measurements/statistics are available as attributes on one virtual sensor.
 
@@ -60,7 +61,7 @@ For Home Assistant to recognize the new integration, restart the server.
 3. **Set the update interval** (how often the statistics should be recalculated).
 4. **Define your measurement points:**
 
-- Choose one or more statistics (min, max, mean, value at, total change).
+- Choose one or more statistics (min, max, mean, sum, value at, total change).
 - Select the time period (e.g., "days ago", "weeks ago", "this year", or "all history").
 - Enter the number of units for the period (e.g., "7 days ago", "1 month ago").
 - Add as many points as you like.

--- a/custom_components/historical_stats/translations/de.json
+++ b/custom_components/historical_stats/translations/de.json
@@ -17,7 +17,9 @@
           "stat_types": "Statistikarten",
           "time_unit": "Zeiteinheit",
           "time_value": "Zeitwert",
-          "add_another": "Weiteren hinzufügen"
+          "add_another": "Weiteren hinzufügen",
+          "time_unit_to": "Zeiteinheit (bis)",
+          "time_value_to": "Zeitwert (bis)"
         }
       }
     }
@@ -39,8 +41,10 @@
         "description": "Stellen Sie die Parameter für den Messpunkt ein.",
         "data": {
           "stat_type": "Statistikart",
-          "time_unit": "Zeiteinheit",
-          "time_value": "Zeitwert"
+          "time_unit": "Zeiteinheit (von)",
+          "time_value": "Zeitwert (von)",
+          "time_unit_to": "Zeiteinheit (bis)",
+          "time_value_to": "Zeitwert (bis)"
         }
       },
       "edit_point": {
@@ -48,8 +52,10 @@
         "description": "Aktualisieren Sie die Parameter für den Messpunkt.",
         "data": {
           "stat_type": "Statistikart",
-          "time_unit": "Zeiteinheit",
-          "time_value": "Zeitwert"
+          "time_unit": "Zeiteinheit (von)",
+          "time_value": "Zeitwert (von)",
+          "time_unit_to": "Zeiteinheit (bis)",
+          "time_value_to": "Zeitwert (bis)"
         }
       }
     }
@@ -59,7 +65,8 @@
     "min": "Minimum",
     "max": "Maximum",
     "mean": "Mittelwert",
-    "total": "Gesamtänderung"
+    "total": "Gesamtänderung",
+    "sum": "Summe"
   },
   "time_unit": {
     "minutes": "Vor Minuten",

--- a/custom_components/historical_stats/translations/dk.json
+++ b/custom_components/historical_stats/translations/dk.json
@@ -17,7 +17,9 @@
           "stat_types": "Statistiktyper",
           "time_unit": "Tidsenhed",
           "time_value": "Tidsværdi",
-          "add_another": "Tilføj en mere"
+          "add_another": "Tilføj en mere",
+          "time_unit_to": "Tidsenhed (til)",
+          "time_value_to": "Tidsværdi (til)"
         }
       }
     }
@@ -39,8 +41,10 @@
         "description": "Indstil parametre for målepunktet.",
         "data": {
           "stat_type": "Statistiktype",
-          "time_unit": "Tidsenhed",
-          "time_value": "Tidsværdi"
+          "time_unit": "Tidsenhed (fra)",
+          "time_value": "Tidsværdi (fra)",
+          "time_unit_to": "Tidsenhed (til)",
+          "time_value_to": "Tidsværdi (til)"
         }
       },
       "edit_point": {
@@ -48,8 +52,10 @@
         "description": "Opdatér parametre for målepunktet.",
         "data": {
           "stat_type": "Statistiktype",
-          "time_unit": "Tidsenhed",
-          "time_value": "Tidsværdi"
+          "time_unit": "Tidsenhed (fra)",
+          "time_value": "Tidsværdi (fra)",
+          "time_unit_to": "Tidsenhed (til)",
+          "time_value_to": "Tidsværdi (til)"
         }
       }
     }
@@ -59,7 +65,8 @@
     "min": "Minimum",
     "max": "Maksimum",
     "mean": "Gennemsnit",
-    "total": "Total ændring"
+    "total": "Total ændring",
+    "sum": "Sum"
   },
   "time_unit": {
     "minutes": "Minutter siden",

--- a/custom_components/historical_stats/translations/en.json
+++ b/custom_components/historical_stats/translations/en.json
@@ -15,8 +15,10 @@
                 "description": "{info}",
                 "data": {
                     "stat_types": "Statistics types",
-                    "time_unit": "Time unit",
-                    "time_value": "Time value",
+                    "time_unit": "Time unit (from)",
+                    "time_value": "Time value (from)",
+                    "time_unit_to": "Time unit (to)",
+                    "time_value_to": "Time value (to)",
                     "add_another": "Add another"
                 }
             }
@@ -40,8 +42,10 @@
                 "description": "Set the parameters for the measurement point.",
                 "data": {
                     "stat_type": "Statistic type",
-                    "time_unit": "Time unit",
-                    "time_value": "Time value"
+                    "time_unit": "Time unit (from)",
+                    "time_value": "Time value (from)",
+                    "time_unit_to": "Time unit (to)",
+                    "time_value_to": "Time value (to)"
                 }
             },
             "edit_point": {
@@ -49,8 +53,10 @@
                 "description": "Update the parameters for the measurement point.",
                 "data": {
                     "stat_type": "Statistic type",
-                    "time_unit": "Time unit",
-                    "time_value": "Time value"
+                    "time_unit": "Time unit (from)",
+                    "time_value": "Time value (from)",
+                    "time_unit_to": "Time unit (to)",
+                    "time_value_to": "Time value (to)"
                 }
             }
         }
@@ -60,7 +66,8 @@
         "min": "Minimum",
         "max": "Maximum",
         "mean": "Mean",
-        "total": "Total change"
+        "total": "Total change",
+        "sum": "Sum"
     },
     "time_unit": {
         "minutes": "Minutes ago",

--- a/custom_components/historical_stats/translations/es.json
+++ b/custom_components/historical_stats/translations/es.json
@@ -17,7 +17,9 @@
           "stat_types": "Tipos de estadísticas",
           "time_unit": "Unidad de tiempo",
           "time_value": "Valor de tiempo",
-          "add_another": "Agregar otro"
+          "add_another": "Agregar otro",
+          "time_unit_to": "Unidad de tiempo (hasta)",
+          "time_value_to": "Valor de tiempo (hasta)"
         }
       }
     }
@@ -39,8 +41,10 @@
         "description": "Establecer los parámetros del punto de medición.",
         "data": {
           "stat_type": "Tipo de estadística",
-          "time_unit": "Unidad de tiempo",
-          "time_value": "Valor de tiempo"
+          "time_unit": "Unidad de tiempo (desde)",
+          "time_value": "Valor de tiempo (desde)",
+          "time_unit_to": "Unidad de tiempo (hasta)",
+          "time_value_to": "Valor de tiempo (hasta)"
         }
       },
       "edit_point": {
@@ -48,8 +52,10 @@
         "description": "Actualice los parámetros del punto de medición.",
         "data": {
           "stat_type": "Tipo de estadística",
-          "time_unit": "Unidad de tiempo",
-          "time_value": "Valor de tiempo"
+          "time_unit": "Unidad de tiempo (desde)",
+          "time_value": "Valor de tiempo (desde)",
+          "time_unit_to": "Unidad de tiempo (hasta)",
+          "time_value_to": "Valor de tiempo (hasta)"
         }
       }
     }
@@ -59,7 +65,8 @@
     "min": "Mínimo",
     "max": "Máximo",
     "mean": "Promedio",
-    "total": "Cambio total"
+    "total": "Cambio total",
+    "sum": "Suma"
   },
   "time_unit": {
     "minutes": "Hace minutos",

--- a/custom_components/historical_stats/translations/fi.json
+++ b/custom_components/historical_stats/translations/fi.json
@@ -17,7 +17,9 @@
           "stat_types": "Tilastotyypit",
           "time_unit": "Aikayksikkö",
           "time_value": "Aika-arvo",
-          "add_another": "Lisää toinen"
+          "add_another": "Lisää toinen",
+          "time_unit_to": "Aikayksikkö (loppu)",
+          "time_value_to": "Aika-arvo (loppu)"
         }
       }
     }
@@ -39,8 +41,10 @@
         "description": "Aseta mittauspisteen parametrit.",
         "data": {
           "stat_type": "Tilastotyyppi",
-          "time_unit": "Aikayksikkö",
-          "time_value": "Aika-arvo"
+          "time_unit": "Aikayksikkö (alku)",
+          "time_value": "Aika-arvo (alku)",
+          "time_unit_to": "Aikayksikkö (loppu)",
+          "time_value_to": "Aika-arvo (loppu)"
         }
       },
       "edit_point": {
@@ -48,8 +52,10 @@
         "description": "Päivitä mittauspisteen parametrit.",
         "data": {
           "stat_type": "Tilastotyyppi",
-          "time_unit": "Aikayksikkö",
-          "time_value": "Aika-arvo"
+          "time_unit": "Aikayksikkö (alku)",
+          "time_value": "Aika-arvo (alku)",
+          "time_unit_to": "Aikayksikkö (loppu)",
+          "time_value_to": "Aika-arvo (loppu)"
         }
       }
     }
@@ -59,7 +65,8 @@
     "min": "Minimi",
     "max": "Maksimi",
     "mean": "Keskiarvo",
-    "total": "Kokonaissmuutos"
+    "total": "Kokonaissmuutos",
+    "sum": "Summa"
   },
   "time_unit": {
     "minutes": "Minuuttia sitten",

--- a/custom_components/historical_stats/translations/no.json
+++ b/custom_components/historical_stats/translations/no.json
@@ -17,7 +17,9 @@
           "stat_types": "Statistikktype(r)",
           "time_unit": "Tidsenhet",
           "time_value": "Tidsverdi",
-          "add_another": "Legg til en til"
+          "add_another": "Legg til en til",
+          "time_unit_to": "Tidsenhet (til)",
+          "time_value_to": "Tidsverdi (til)"
         }
       }
     }
@@ -39,8 +41,10 @@
         "description": "Angi parametere for målepunktet.",
         "data": {
           "stat_type": "Statistikktype",
-          "time_unit": "Tidsenhet",
-          "time_value": "Tidsverdi"
+          "time_unit": "Tidsenhet (fra)",
+          "time_value": "Tidsverdi (fra)",
+          "time_unit_to": "Tidsenhet (til)",
+          "time_value_to": "Tidsverdi (til)"
         }
       },
       "edit_point": {
@@ -48,8 +52,10 @@
         "description": "Oppdater parametere for målepunktet.",
         "data": {
           "stat_type": "Statistikktype",
-          "time_unit": "Tidsenhet",
-          "time_value": "Tidsverdi"
+          "time_unit": "Tidsenhet (fra)",
+          "time_value": "Tidsverdi (fra)",
+          "time_unit_to": "Tidsenhet (til)",
+          "time_value_to": "Tidsverdi (til)"
         }
       }
     }
@@ -59,7 +65,8 @@
     "min": "Minimum",
     "max": "Maksimum",
     "mean": "Gjennomsnitt",
-    "total": "Total endring"
+    "total": "Total endring",
+    "sum": "Sum"
   },
   "time_unit": {
     "minutes": "Minutter siden",

--- a/custom_components/historical_stats/translations/sv.json
+++ b/custom_components/historical_stats/translations/sv.json
@@ -17,7 +17,9 @@
           "stat_types": "Statistiktyp(er)",
           "time_unit": "Tidsenhet",
           "time_value": "Tidsvärde",
-          "add_another": "Lägg till en till"
+          "add_another": "Lägg till en till",
+          "time_unit_to": "Tidsenhet (till)",
+          "time_value_to": "Tidsvärde (till)"
         }
       }
     }
@@ -39,8 +41,10 @@
         "description": "Ställ in parametrar för mätpunkten.",
         "data": {
           "stat_type": "Statistiktyp",
-          "time_unit": "Tidsenhet",
-          "time_value": "Tidsvärde"
+          "time_unit": "Tidsenhet (från)",
+          "time_value": "Tidsvärde (från)",
+          "time_unit_to": "Tidsenhet (till)",
+          "time_value_to": "Tidsvärde (till)"
         }
       },
       "edit_point": {
@@ -48,8 +52,10 @@
         "description": "Uppdatera parametrarna för mätpunkten.",
         "data": {
           "stat_type": "Statistiktyp",
-          "time_unit": "Tidsenhet",
-          "time_value": "Tidsvärde"
+          "time_unit": "Tidsenhet (från)",
+          "time_value": "Tidsvärde (från)",
+          "time_unit_to": "Tidsenhet (till)",
+          "time_value_to": "Tidsvärde (till)"
         }
       }
     }
@@ -59,7 +65,8 @@
     "min": "Minsta",
     "max": "Högsta",
     "mean": "Medelvärde",
-    "total": "Total förändring"
+    "total": "Total förändring",
+    "sum": "Summa"
   },
   "time_unit": {
     "minutes": "Minuter sedan",


### PR DESCRIPTION
## Summary
- allow all statistic types to be combined when adding points
- add new **sum** statistic type
- support custom end times for each measurement

## Testing
- `scripts/lint.sh`

------
https://chatgpt.com/codex/tasks/task_e_68810ceb4d648328ad5e29401604ce5e